### PR TITLE
Replace JCenter with Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -40,7 +40,7 @@ subprojects {
     }
 
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     tasks.withType(Javadoc).all {


### PR DESCRIPTION
This replaces jcenter with maven central to avoid broken builds in the future

