### PR TITLE
Don't insert into the event map if a property value is null

### DIFF
--- a/mql-jvm/src/main/clojure/io/mantisrx/mql/compilers/core/select.cljc
+++ b/mql-jvm/src/main/clojure/io/mantisrx/mql/compilers/core/select.cljc
@@ -11,9 +11,11 @@
    new nested TreeMaps as necessary if nested levels do not exist."
   {:static true}
   [m [k & ks] v]
-  (if ks
-    (.put ^java.util.Map m k (map-assoc-in! (get m k (java.util.TreeMap.)) ks v))
-    (.put ^java.util.Map m k v))
+  (if (not (nil? v))
+    (if ks
+      (.put ^java.util.Map m k (map-assoc-in! (get m k (java.util.TreeMap.)) ks v))
+      (.put ^java.util.Map m k v))
+    m)
   m))
 
 (defn asterisk->fn

--- a/mql-jvm/src/test/clojure/io/mantisrx/mql/test_query.clj
+++ b/mql-jvm/src/test/clojure/io/mantisrx/mql/test_query.clj
@@ -228,7 +228,15 @@
       [q "select 1 as 'test_id', 'b' as 'code', 3.14 as 'pi', a as 'prop' from stream"
        context {"stream" (Observable/just {"a" 1})}
        result (rxb/into [] (eval-mql q context "client"))]
-      (is (= [{"test_id" 1, "code" "b", "pi" 3.14, "prop" 1}] result)))))
+      (is (= [{"test_id" 1, "code" "b", "pi" 3.14, "prop" 1}] result))))
+
+  (testing "select a nil value with as clause does not insert it in client mode"
+    (let
+      [q "select a as 'test', b as 'test' from stream"
+       context {"stream" (Observable/just {"a" 1})}
+       result (rxb/into [] (eval-mql q context "client"))]
+      (is (= [{"test" 1}] result))))
+  )
 
 ;;;;
 ;;;; Spaces in Properties


### PR DESCRIPTION
### Context

A subtle change with big implications for the use of MQL. If a property has two potential locations in a `SELECT` list we now have the ability to ensure a common destination using only MQL. For example imagine a scenario existed where request success was indicated in one of two locations: `SELECT e['response.body']['success'], e['response.body']['manifest_response']['success']...` can now be written as `SELECT e['response.body']['success'] AS "success", e['response.body']['manifest_response']['success'] AS "success"...` without fear of the non-present value clobbering the present one depending on execution order. Java code accessing the resulting values simply needs to look for `success` as a top level property.

Another example is querying request headers from mixed Base Server and Spring Boot applications. Spring boot writes a much more structured payload and it is currently difficult for consumers to manage canonicalizing their events before processing.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
