### PR TITLE
perf(optimization): rewrite the regex->string-op rules to cover real queries

### DIFF
--- a/mql-jvm/src/main/clojure/io/mantisrx/mql/compilers/core/where.cljc
+++ b/mql-jvm/src/main/clojure/io/mantisrx/mql/compilers/core/where.cljc
@@ -3,6 +3,79 @@
 
 
 
+;;;; ---------------------------------------------------------------------------
+;;;; ASCII case folding
+;;;;
+;;;; The optimizer rewrites `(?i)`-flagged regexes into the `*i` operators below, so those
+;;;; operators must fold exactly the way `(?i)` does -- and no more. MQL compiles patterns with
+;;;; DOTALL only (see transformers.cljc), so `(?i)` is Java's *ASCII-only* case insensitivity:
+;;;; UNICODE_CASE is never set. `equalsIgnoreCase` and `regionMatches(true, ...)` fold over the
+;;;; full Unicode case tables and therefore accept strings the regex rejects -- U+017F LATIN
+;;;; SMALL LETTER LONG S vs "s", U+212A KELVIN SIGN vs "k", U+0130 vs "i", and every accented
+;;;; pair. Folding A-Z and nothing else is the only exact equivalent.
+;;;;
+;;;; The comparisons scan characters in place rather than lower-casing their operands, because
+;;;; these run once per registered query per event: folding would allocate a String per event
+;;;; per term, which is most of what rewriting away the regex was meant to save.
+;;;; ---------------------------------------------------------------------------
+
+#?(:clj
+   (defn- ascii-lower
+     ^long [^long c]
+     (if (and (>= c 65) (<= c 90)) (+ c 32) c)))
+
+#?(:clj
+   (defn- ci-region=
+     "True when term occurs in s at offset off, comparing with ASCII-only case folding."
+     [^String s ^long off ^String term]
+     (let [n (.length term)]
+       (and (<= (+ off n) (.length s))
+            (loop [i 0]
+              (cond
+                (>= i n) true
+                (== (ascii-lower (long (.charAt s (+ off i))))
+                    (ascii-lower (long (.charAt term i)))) (recur (inc i))
+                :else false))))))
+
+#?(:cljs
+   (defn- ascii-fold [s] (string/replace (str s) #"[A-Z]" (fn [c] (.toLowerCase c)))))
+
+(defn- ci-equals?
+  [target ^String term]
+  #?(:clj (let [^String s (str target)]
+            (and (== (.length s) (.length term)) (ci-region= s 0 term)))
+     :cljs (= (ascii-fold (str target)) (ascii-fold term))))
+
+(defn- ci-starts-with?
+  [target ^String term]
+  #?(:clj (ci-region= (str target) 0 term)
+     :cljs (string/starts-with? (ascii-fold (str target)) (ascii-fold term))))
+
+(defn- ci-ends-with?
+  [target ^String term]
+  #?(:clj (let [^String s (str target)
+                off (- (.length s) (.length term))]
+            (and (>= off 0) (ci-region= s off term)))
+     :cljs (string/ends-with? (ascii-fold (str target)) (ascii-fold term))))
+
+(defn- ci-includes?
+  [target ^String term]
+  #?(:clj (let [^String s (str target)
+                lim (- (.length s) (.length term))]
+            (loop [i 0]
+              (cond
+                (> i lim) false
+                (ci-region= s i term) true
+                :else (recur (inc i)))))
+     :cljs (string/includes? (ascii-fold (str target)) (ascii-fold term))))
+
+(defn- coll-some
+  "The terms operand is a collection when the optimizer folded an alternation into one
+   operator and a bare string otherwise; both spellings are accepted, as for ==+ and ==*."
+  [pred terms]
+  (let [terms (if (coll? terms) terms [terms])]
+    (boolean (some pred terms))))
+
 (def ^:private ops {
                     "=" =
                     "==" =
@@ -26,8 +99,26 @@
                               [terms (if (coll? terms) terms [terms])
                                target (str target)]
                               (some #(= %1 target) terms)))
-                    "startsWith" (fn [target ^String term]
-                                   (.startsWith ^String (str target) term))
+                    ;; Accepts a collection as well as a single term, as ==+ and ==* do: the
+                    ;; optimizer emits a collection when it folds an alternation into one
+                    ;; operator, e.g. /(abc|def).*/ -> startsWith ("abc" "def").
+                    "startsWith" (fn [target terms]
+                                   (coll-some
+                                     #(.startsWith ^String (str target) ^String %1)
+                                     terms))
+
+                    ;; Emitted only by the optimizer, which rewrites an equivalent regex into
+                    ;; one of these. See optimization.cljc for which shape produces which.
+                    "endsWith" (fn [target terms]
+                                 (coll-some
+                                   #(.endsWith ^String (str target) ^String %1)
+                                   terms))
+                    "==i" (fn [target terms] (coll-some #(ci-equals? target %1) terms))
+                    "==+i" (fn [target terms] (coll-some #(ci-includes? target %1) terms))
+                    "startsWithi" (fn [target terms]
+                                    (coll-some #(ci-starts-with? target %1) terms))
+                    "endsWithi" (fn [target terms]
+                                  (coll-some #(ci-ends-with? target %1) terms))
                     })
 
 (defn where-clause->fn

--- a/mql-jvm/src/main/clojure/io/mantisrx/mql/jvm/optimization.clj
+++ b/mql-jvm/src/main/clojure/io/mantisrx/mql/jvm/optimization.clj
@@ -30,129 +30,309 @@
        (zip/edit loc (:apply rule))
        loc))
 
-(defn- regex-to-contains
-  "Helper method for turning a regex into a string contains.
-   Does not check for valid input"
-  [regex]
-  [:string_literal (str "'" (subs (second regex)
-                         2
-                         (- (count (second regex)) 2))
-                        "'")])
+;;;; ---------------------------------------------------------------------------------
+;;;; The literal class.
+;;;;
+;;;; Every rule below shares this one definition. A regex "word" is any run of
+;;;; characters that carry no regex meaning: either a non-metacharacter, or a backslash
+;;;; escape. Java's Pattern accepts \X for every non-alphanumeric X and treats it as a
+;;;; literal X, so the escape branch admits exactly that set -- no narrower, or the
+;;;; rules decline patterns they could have rewritten, and no wider, or \d / \w / \1
+;;;; would be mistaken for literals.
+;;;;
+;;;; `unescape` below must strip exactly the escapes this class admits. If the two
+;;;; disagree, a rule fires and emits a term that still contains a backslash, and the
+;;;; resulting string comparison silently matches nothing.
+;;;; ---------------------------------------------------------------------------------
 
-;;;; Regex below defines a "word" for MQL optimization purposes.
-;;;; This is any unit of text that we might consider an input token
-;;;; to a regex which we might extract and use in other manners.
-;;;; Allows any character that is a literal in a regex -- i.e. anything that is
-;;;; not a metacharacter -- plus a backslash escape of any metacharacter. Every
-;;;; character outside the metacharacter set matches only itself, so a pattern
-;;;; built solely from them is exactly a literal string.
-(def word-regex
-  #"(?:[^\\.*+?()\[\]{}|^$]|\\[.*+?()\[\]{}|^$\\/\"])+"
-  )
+(def ^:private word-src
+  "(?:[^\\\\.*+?()\\[\\]{}|^$]|\\\\[^A-Za-z0-9])+")
 
-;;;; Strips the backslash from every escape word-regex admits. Single-pass and
-;;;; left-to-right, so an escaped backslash consumes its own escapee rather than
-;;;; being re-examined as the escape of the character after it.
+(def word-regex (re-pattern word-src))
+
 (defn unescape
+  "Strips the backslash from every escape word-regex admits. Single-pass and
+   left-to-right, so an escaped backslash consumes its own escapee rather than being
+   re-examined as the escape of the character after it."
   [x]
-  (string/replace x #"\\([.*+?()\[\]{}|^$\\/\"])" "$1"))
+  (string/replace x #"\\([^A-Za-z0-9])" "$1"))
+
+;;;; ---------------------------------------------------------------------------------
+;;;; Terminal shapes. Each captures the literal in group 1, so the term is read off the
+;;;; match rather than recovered by index arithmetic on the pattern text.
+;;;;
+;;;; `^` and `$` are accepted and discarded. MQL evaluates ==~ with Matcher.matches,
+;;;; which already requires the whole input to be consumed, so a leading `^` and a
+;;;; trailing `$` are both no-ops -- including the `$`-before-final-newline case, since
+;;;; a leftover trailing newline fails the full-region match either way.
+;;;;
+;;;; The four shapes are mutually exclusive: the literal class excludes `.` and `*`, so
+;;;; no pattern can satisfy two of them.
+;;;; ---------------------------------------------------------------------------------
+
+(def ^:private equals-re   (re-pattern (str "\\^?(" word-src ")\\$?")))
+(def ^:private starts-re   (re-pattern (str "\\^?(" word-src ")\\.\\*")))
+(def ^:private ends-re     (re-pattern (str "\\.\\*(" word-src ")\\$?")))
+(def ^:private contains-re (re-pattern (str "\\^?\\.\\*(" word-src ")\\.\\*\\$?")))
+
+(defn- split-ci
+  "Returns [case-insensitive? body] for a pattern, or nil if the pattern uses any
+   inline construct other than a single leading (?i). (?i) without UNICODE_CASE folds
+   the ASCII range only, which the ==i / ==+i operators reproduce exactly; every other
+   (?...) group -- lookahead, non-capturing, other flags -- is left as a regex."
+  [p]
+  (let [ci?  (string/starts-with? p "(?i)")
+        body (if ci? (subs p 4) p)]
+    (when-not (string/includes? body "(?")
+      [ci? body])))
+
+(defn- regex-node?
+  [node]
+  (and (vector? node)
+       (= :boolean_test (first node))
+       (= 4 (count node))
+       (vector? (nth node 2))
+       (= :REGEX_OPERATOR (first (nth node 2)))
+       (vector? (last node))
+       (string? (second (last node)))))
+
+(defn- terminal-rule
+  "Builds a rule that rewrites one terminal shape into a string operator.
+   `ci-op` is used only when the literal actually contains an ASCII letter: (?i) over a
+   literal with no letters folds nothing, so those collapse to the cheaper exact op."
+  [shape-re plain-op ci-op]
+  {:pred (fn [node]
+           (and (regex-node? node)
+                (let [[_ body] (split-ci (second (last node)))]
+                  (boolean (and body (re-matches shape-re body))))))
+   :apply (fn [node]
+            (let [[ci? body] (split-ci (second (last node)))
+                  term (unescape (second (re-matches shape-re body)))
+                  fold? (and ci? (boolean (re-find #"[A-Za-z]" term)))]
+              [:boolean_test
+               (second node)
+               [:BINARY_OPERATOR (if fold? ci-op plain-op)]
+               term]))})
+
+;;;; ---------------------------------------------------------------------------------
+;;;; Alternation.
+;;;;
+;;;; Because ==~ is a full-region match, matches(A|B|C) is exactly
+;;;; matches(A) or matches(B) or matches(C) -- the alternation distributes over the
+;;;; whole predicate. So an alternation is split into an OR of independent tests and
+;;;; each branch picks its own operator.
+;;;;
+;;;; This is the only correct treatment. Collapsing an alternation into a single list
+;;;; operator is wrong whenever the branches do not all have the same shape:
+;;;; `.*Error.*|.*Fatal` is contains-or-endsWith, and evaluating it as
+;;;; contains-any(Error, Fatal) reports a match for "xFatalY", which the regex rejects.
+;;;;
+;;;; The split only fires when *every* branch is itself a terminal shape. A branch that
+;;;; stayed a regex would leave two Matcher.matches calls where there was one.
+;;;; ---------------------------------------------------------------------------------
+
+(defn- scan-alternatives
+  "Splits on the `|` at group depth 0, honouring backslash escapes -- an escaped `\\|` is a
+   literal and not a separator. Returns nil if the pattern uses a character class or a
+   backreference, or if its parens are unbalanced; otherwise a vector of branches, which
+   is a single element when there is no top-level `|`.
+
+   A plain string/split on `|` cannot be used here: it would cut `a\\|b|c` into three
+   branches instead of two, and the resulting terms would carry a stray backslash."
+  [body]
+  (let [n (count body)]
+    (loop [i 0 depth 0 start 0 acc []]
+      (if (>= i n)
+        (when (zero? depth) (conj acc (subs body start)))
+        (let [c (.charAt ^String body i)]
+          (cond
+            (= c \\) (when-not (and (< (inc i) n)
+                                    (Character/isDigit (.charAt ^String body (inc i))))
+                       (recur (+ i 2) depth start acc))
+            (= c \[) nil
+            (= c \() (recur (inc i) (inc depth) start acc)
+            (= c \)) (if (zero? depth) nil (recur (inc i) (dec depth) start acc))
+            (and (= c \|) (zero? depth))
+            (recur (inc i) depth (inc i) (conj acc (subs body start i)))
+            :else (recur (inc i) depth start acc)))))))
+
+(defn- top-level-alternatives
+  "scan-alternatives, but only when there really is a top-level alternation to split."
+  [body]
+  (when-let [branches (scan-alternatives body)]
+    (when (> (count branches) 1) branches)))
+
+(def ^:private terminal-shapes [equals-re starts-re ends-re contains-re])
+
+(defn- terminal-branch?
+  [branch]
+  (and (not (string/includes? branch "(?"))
+       (boolean (some #(re-matches % branch) terminal-shapes))))
+
+(defn- or-tree
+  "Left-nested OR, matching the grammar's
+   search_condition = boolean_term | search_condition or_kw boolean_term."
+  [tests]
+  (reduce (fn [acc t] [:search_condition acc [:or_kw "or"] t])
+          (first tests)
+          (rest tests)))
+
+(def ^:private alternation-split-rule
+  {:pred (fn [node]
+           (and (regex-node? node)
+                (let [[_ body] (split-ci (second (last node)))]
+                  (boolean
+                    (when body
+                      (when-let [branches (top-level-alternatives body)]
+                        (and (> (count branches) 1)
+                             (every? terminal-branch? branches))))))))
+   :apply (fn [node]
+            (let [[ci? body] (split-ci (second (last node)))
+                  prefix (if ci? "(?i)" "")
+                  branches (top-level-alternatives body)]
+              ;; The wrapping :boolean_test is what keeps this rewrite composable.
+              ;; binary-expr->pred has a 1-arity pass-through, so a :boolean_test with a
+              ;; single child transforms to just that child's predicate -- the node tag
+              ;; survives for any enclosing rule, and zip/next descends into the new
+              ;; children, so the terminal rules above rewrite each branch in this pass.
+              [:boolean_test
+               (or-tree (for [b branches]
+                          [:boolean_test
+                           (second node)
+                           [:REGEX_OPERATOR "==~"]
+                           [:re_expression (str prefix b)]]))]))})
+
+;;;; A group wrapping the entire pattern carries no meaning once there are no
+;;;; backreferences, and removing it lets the alternation split see the `|`s as
+;;;; top-level: `(master|release)` becomes `master|release`.
+
+(defn- self-contained-group?
+  "True when body is a single group spanning the whole pattern -- `(a|b)` and not
+   `(a)(b)`, which would lose the concatenation if the outer parens were dropped."
+  [body]
+  (and (string/starts-with? body "(")
+       (string/ends-with? body ")")
+       (not (re-find #"\\[1-9]" body))
+       (let [inner (subs body 1 (dec (count body)))
+             n (count inner)]
+         (and (pos? n)
+              (loop [i 0 depth 0]
+                (cond
+                  (>= i n) (zero? depth)
+                  (= \\ (.charAt ^String inner i)) (recur (+ i 2) depth)
+                  (= \( (.charAt ^String inner i)) (recur (inc i) (inc depth))
+                  (= \) (.charAt ^String inner i)) (if (zero? depth)
+                                                     false
+                                                     (recur (inc i) (dec depth)))
+                  :else (recur (inc i) depth)))))))
+
+(def ^:private strip-outer-group-rule
+  {:pred (fn [node]
+           (and (regex-node? node)
+                (let [[_ body] (split-ci (second (last node)))]
+                  (boolean (and body (self-contained-group? body))))))
+   :apply (fn [node]
+            (let [[ci? body] (split-ci (second (last node)))]
+              [:boolean_test
+               (second node)
+               [:REGEX_OPERATOR "==~"]
+               [:re_expression (str (if ci? "(?i)" "")
+                                    (subs body 1 (dec (count body))))]]))})
+
+;;;; Uniform alternations. When every branch of an alternation is a bare literal, every
+;;;; branch really does reduce to the same operator, so the whole pattern collapses to one
+;;;; list operator instead of the chain of ORs the general split would produce. Literals
+;;;; adjacent to the group distribute into each term: `pre(a|b)post` is
+;;;; equals-any(preapost, prebpost).
+;;;;
+;;;; Anything these decline -- in particular any alternation whose branches have differing
+;;;; shapes -- falls through to alternation-split-rule, which is the only correct treatment
+;;;; there. Collapsing a mixed alternation into one list operator is a real bug:
+;;;; `.*Error.*|.*Fatal` as contains-any(Error, Fatal) accepts "xFatalY", which the regex
+;;;; rejects.
+
+(defn- alt-rule
+  "Builds a rule for `<lead><prefix>(a|b|...)<suffix><trail>`, where lead/trail are the
+   fixed `.*` decorations that select the operator and prefix/suffix are optional
+   literals that distribute into every term."
+  [lead trail plain-op ci-op]
+  (let [shape (re-pattern (str "\\^?" lead "(" word-src ")?\\((" word-src
+                               "(?:\\|" word-src ")*)\\)(" word-src ")?" trail "\\$?"))]
+    {:pred (fn [node]
+             (and (regex-node? node)
+                  (let [[_ body] (split-ci (second (last node)))]
+                    (boolean (and body (re-matches shape body))))))
+     :apply (fn [node]
+              (let [[ci? body] (split-ci (second (last node)))
+                    [_ prefix alts suffix] (re-matches shape body)
+                    prefix (unescape (or prefix ""))
+                    suffix (unescape (or suffix ""))
+                    words (map #(str prefix (unescape %) suffix)
+                               (scan-alternatives alts))
+                    fold? (and ci? (boolean (some #(re-find #"[A-Za-z]" %) words)))]
+                [:boolean_test
+                 (second node)
+                 [:BINARY_OPERATOR (if fold? ci-op plain-op)]
+                 words]))}))
+
+;;;; The paren-free form, `a|b|c`. strip-outer-group-rule has already unwrapped
+;;;; `(a|b|c)` by the time this runs, so this covers both.
+(def ^:private bare-multi-equals-rule
+  ;; The whole alternation is a capture group rather than something recovered by trimming
+  ;; `^`/`$` off the ends: a pattern may legitimately *end* in an escaped `\$`, and a
+  ;; trailing-`$` string replace would eat that dollar and leave a dangling backslash in
+  ;; the term. Reading the group off the match cannot make that mistake, because the
+  ;; literal class already decided which dollar is a metacharacter.
+  (let [shape (re-pattern (str "\\^?((?:" word-src ")(?:\\|(?:" word-src "))+)\\$?"))]
+    {:pred (fn [node]
+             (and (regex-node? node)
+                  (let [[_ body] (split-ci (second (last node)))]
+                    (boolean (and body (re-matches shape body))))))
+     :apply (fn [node]
+              (let [[ci? body] (split-ci (second (last node)))
+                    words (map unescape (scan-alternatives (second (re-matches shape body))))
+                    fold? (and ci? (boolean (some #(re-find #"[A-Za-z]" %) words)))]
+                [:boolean_test
+                 (second node)
+                 [:BINARY_OPERATOR (if fold? "==i" "==*")]
+                 words]))}))
+
+;;;; ---------------------------------------------------------------------------------
+;;;; Rule order is significant. `reduce` threads one location through every rule in
+;;;; turn, so a rule sees whatever its predecessors produced:
+;;;;
+;;;;   strip-outer-group  runs first so the multi-term rules and the split see the
+;;;;                      unwrapped pattern.
+;;;;   terminals          run before the multi-term rules, so a single-literal pattern
+;;;;                      becomes `==` rather than a one-element `==*`.
+;;;;   multi-term rules   take the uniform alternations, which they express as one list
+;;;;                      operator.
+;;;;   alternation-split  is the fallback for every other alternation, and cannot loop:
+;;;;                      its output branches contain no top-level `|`.
+;;;;
+;;;; A rule that has already fired leaves a :BINARY_OPERATOR behind, so every later
+;;;; predicate declines it via regex-node?.
+;;;; ---------------------------------------------------------------------------------
 
 (def optimization-rules
-  [
-   ;;;; Basic equals rule, converts foo ==~ /abcd/ into an equals call.
-   {:pred (fn [node] (and (= :boolean_test (first node))
-                          (= (first (nth node 2)) :REGEX_OPERATOR)
-                          (re-matches
-                            word-regex
-                            (second (last node)))))
-    :apply (fn [node] [:boolean_test
-                       (second node)
-                       [:BINARY_OPERATOR "=="]
-                       (unescape (second (last node)))
-                       ])}
+  [strip-outer-group-rule
 
-   ;;;; Basic starts with rule, converts foo ==~ /abcd.*/ into a startswith call.
-   {:pred (fn [node] (and (= :boolean_test (first node))
-                         (= (first (nth node 2)) :REGEX_OPERATOR)
-                         (re-matches
-                           #"\^?(?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\"|\\/|\\\(|\\\)|\\\{|\\\})+\.\*$"
-                           (second (last node)))))
-   :apply (fn [node] [:boolean_test
-                      (second node)
-                      [:BINARY_OPERATOR "startsWith"]
-                      (clojure.string/replace
-                        (unescape (subs (second (last node)) 0 (- (count (second (last node))) 2)))
-                        #"^\^"
-                        "")]) 
-   }
+   (terminal-rule equals-re   "==" "==i")
+   (terminal-rule starts-re   "startsWith" "startsWithi")
+   (terminal-rule ends-re     "endsWith" "endsWithi")
+   (terminal-rule contains-re "==+" "==+i")
 
-   ;;;; Basic contrains rule, converts foo ==~ /.*abcd.*/ into a contains call.
-   {:pred (fn [node] (and (= :boolean_test (first node))
-                          (= (first (nth node 2)) :REGEX_OPERATOR)
-                          (re-matches
-                            #"\.\*(?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\"|\\/|\\\(|\\\)|\\\{|\\\})+\.\*"
-                            (second (last node)))))
-    :apply (fn [node] [:boolean_test
-                       (second node)
-                       [:BINARY_OPERATOR "==+"]
-                        (unescape (subs (second (last node)) 2 (- (count (second (last node))) 2)))
-                        ])}
+   bare-multi-equals-rule
+   (alt-rule ""       ""       "==*" "==i")
+   (alt-rule "\\.\\*" "\\.\\*" "==+" "==+i")
+   (alt-rule ""       "\\.\\*" "startsWith" "startsWithi")
+   (alt-rule "\\.\\*" ""       "endsWith" "endsWithi")
 
-   ;;;; Multiple equals rule, converts foo ==~ /abc|def|ghi/ into multiple equals calls. 
-   {:pred (fn [node] (and (= :boolean_test (first node))
-                          (= (first (nth node 2)) :REGEX_OPERATOR)
-                          (re-matches
-                            #"(?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\"|\\/|\\\(|\\\)|\\\{|\\\})+(\|(?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\"|\\/|\\\(|\\\)|\\\{|\\\})+)*"
-                                      (second (last node)))))
-    :apply (fn [node] 
-             (let
-               [target (subs (second (last node)) 3 (- (count (second (last node))) 3))
-                words (map unescape (string/split (second (last node)) #"\|"))
-                ]
-               [:boolean_test
-                (second node)
-                [:BINARY_OPERATOR "==*"]
-                words])
-             )}
-
-   ;;;; Multiple contrains rule, converts foo ==~ /.*(abc|def).*/ into multiple contains calls.
-   {:pred (fn [node] (and (= :boolean_test (first node))
-                          (= (first (nth node 2)) :REGEX_OPERATOR)
-                          (re-matches
-                            #"\.\*\((?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\"|\\/|\\\(|\\\)|\\\{|\\\})+(\|(?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\"|\\/|\\\(|\\\)|\\\{|\\\})+)*\)\.\*"
-                                      (second (last node)))))
-    :apply (fn [node] 
-             (let
-               [target (subs (second (last node)) 3 (- (count (second (last node))) 3))
-                words (map unescape (string/split target #"\|"))]
-               [:boolean_test
-                (second node)
-                [:BINARY_OPERATOR "==+"]
-                words])
-             )}
-
-   ;;;; Prefix multiple contrains rule, converts foo ==~ /.*(abc|def)ghi.*/ into multiple contains calls.
-   {:pred (fn [node] (and (= :boolean_test (first node))
-                          (= (first (nth node 2)) :REGEX_OPERATOR)
-                          (re-matches
-                            #"\.\*\((?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\"|\\/|\\\(|\\\)|\\\{|\\\})+(\|(?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\"|\\/|\\\(|\\\)|\\\{|\\\})+)+\)(?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\ |\\/|\\\(|\\\)|\\\{|\\\})+\.\*"
-                                      (second (last node)))))
-    :apply (fn [node] 
-             (let
-               [target (subs (second (last node)) 3 (- (count (second (last node))) 2))
-                ;; TODO: Separate the tail, and then this will be the same.
-                tail (last (string/split target #"\)"))
-                words (map unescape (string/split (string/replace target (str ")" tail) "") #"\|"))]
-               [:boolean_test
-                (second node)
-                [:BINARY_OPERATOR "==+"]
-                (map #(str %1 tail) words)])
-             )}
-   ])
+   alternation-split-rule])
 
 (defn- apply-rules
   [loc rules]
-  (reduce apply-rule loc optimization-rules))
+  (reduce apply-rule loc rules))
 
 (defn run
   [loc]

--- a/mql-jvm/src/main/clojure/io/mantisrx/mql/jvm/optimization.clj
+++ b/mql-jvm/src/main/clojure/io/mantisrx/mql/jvm/optimization.clj
@@ -42,24 +42,20 @@
 ;;;; Regex below defines a "word" for MQL optimization purposes.
 ;;;; This is any unit of text that we might consider an input token
 ;;;; to a regex which we might extract and use in other manners.
-;;;; Allows alphanumeric, _, :, double quotes, -, \., \:, \", \/, \(, \)
-;;;; This allows users to search JSON
+;;;; Allows any character that is a literal in a regex -- i.e. anything that is
+;;;; not a metacharacter -- plus a backslash escape of any metacharacter. Every
+;;;; character outside the metacharacter set matches only itself, so a pattern
+;;;; built solely from them is exactly a literal string.
 (def word-regex
-  #"(?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\"|\\/|\\\(|\\\)|\\\{|\\\})+"
+  #"(?:[^\\.*+?()\[\]{}|^$]|\\[.*+?()\[\]{}|^$\\/\"])+"
   )
 
+;;;; Strips the backslash from every escape word-regex admits. Single-pass and
+;;;; left-to-right, so an escaped backslash consumes its own escapee rather than
+;;;; being re-examined as the escape of the character after it.
 (defn unescape
   [x]
-  (-> x
-       (string/replace "\\:" ":")
-       (string/replace "\\." ".")
-       (string/replace "\\/" "/")
-       (string/replace "\\(" "(")
-       (string/replace "\\)" ")")
-       (string/replace "\\\"" "\"")
-       (string/replace "\\}" "}")
-       (string/replace "\\{" "{")
-       ))
+  (string/replace x #"\\([.*+?()\[\]{}|^$\\/\"])" "$1"))
 
 (def optimization-rules
   [

--- a/mql-jvm/src/main/clojure/io/mantisrx/mql/optimization.cljc
+++ b/mql-jvm/src/main/clojure/io/mantisrx/mql/optimization.cljc
@@ -1,10 +1,4 @@
 (ns io.mantisrx.mql.optimization
-  "Query optimization functions, the objective
-   of this namespace is to take a parse tree
-   from the parser and produce a higher performing but equivalent tree.
-   
-   Note that the pred and apply functions execute at compile time for the query
-   and thus should "
   (:require [clojure.zip :as zip]
             [clojure.string :as string]))
 
@@ -15,129 +9,309 @@
        (zip/edit loc (:apply rule))
        loc))
 
-(defn- regex-to-contains
-  "Helper method for turning a regex into a string contains.
-   Does not check for valid input"
-  [regex]
-  [:string_literal (str "'" (subs (second regex)
-                         2
-                         (- (count (second regex)) 2))
-                        "'")])
+;;;; ---------------------------------------------------------------------------------
+;;;; The literal class.
+;;;;
+;;;; Every rule below shares this one definition. A regex "word" is any run of
+;;;; characters that carry no regex meaning: either a non-metacharacter, or a backslash
+;;;; escape. Java's Pattern accepts \X for every non-alphanumeric X and treats it as a
+;;;; literal X, so the escape branch admits exactly that set -- no narrower, or the
+;;;; rules decline patterns they could have rewritten, and no wider, or \d / \w / \1
+;;;; would be mistaken for literals.
+;;;;
+;;;; `unescape` below must strip exactly the escapes this class admits. If the two
+;;;; disagree, a rule fires and emits a term that still contains a backslash, and the
+;;;; resulting string comparison silently matches nothing.
+;;;; ---------------------------------------------------------------------------------
 
-;;;; Regex below defines a "word" for MQL optimization purposes.
-;;;; This is any unit of text that we might consider an input token
-;;;; to a regex which we might extract and use in other manners.
-;;;; Allows any character that is a literal in a regex -- i.e. anything that is
-;;;; not a metacharacter -- plus a backslash escape of any metacharacter. Every
-;;;; character outside the metacharacter set matches only itself, so a pattern
-;;;; built solely from them is exactly a literal string.
-(def word-regex
-  #"(?:[^\\.*+?()\[\]{}|^$]|\\[.*+?()\[\]{}|^$\\/\"])+"
-  )
+(def ^:private word-src
+  "(?:[^\\\\.*+?()\\[\\]{}|^$]|\\\\[^A-Za-z0-9])+")
 
-;;;; Strips the backslash from every escape word-regex admits. Single-pass and
-;;;; left-to-right, so an escaped backslash consumes its own escapee rather than
-;;;; being re-examined as the escape of the character after it.
+(def word-regex (re-pattern word-src))
+
 (defn unescape
+  "Strips the backslash from every escape word-regex admits. Single-pass and
+   left-to-right, so an escaped backslash consumes its own escapee rather than being
+   re-examined as the escape of the character after it."
   [x]
-  (string/replace x #"\\([.*+?()\[\]{}|^$\\/\"])" "$1"))
+  (string/replace x #"\\([^A-Za-z0-9])" "$1"))
+
+;;;; ---------------------------------------------------------------------------------
+;;;; Terminal shapes. Each captures the literal in group 1, so the term is read off the
+;;;; match rather than recovered by index arithmetic on the pattern text.
+;;;;
+;;;; `^` and `$` are accepted and discarded. MQL evaluates ==~ with Matcher.matches,
+;;;; which already requires the whole input to be consumed, so a leading `^` and a
+;;;; trailing `$` are both no-ops -- including the `$`-before-final-newline case, since
+;;;; a leftover trailing newline fails the full-region match either way.
+;;;;
+;;;; The four shapes are mutually exclusive: the literal class excludes `.` and `*`, so
+;;;; no pattern can satisfy two of them.
+;;;; ---------------------------------------------------------------------------------
+
+(def ^:private equals-re   (re-pattern (str "\\^?(" word-src ")\\$?")))
+(def ^:private starts-re   (re-pattern (str "\\^?(" word-src ")\\.\\*")))
+(def ^:private ends-re     (re-pattern (str "\\.\\*(" word-src ")\\$?")))
+(def ^:private contains-re (re-pattern (str "\\^?\\.\\*(" word-src ")\\.\\*\\$?")))
+
+(defn- split-ci
+  "Returns [case-insensitive? body] for a pattern, or nil if the pattern uses any
+   inline construct other than a single leading (?i). (?i) without UNICODE_CASE folds
+   the ASCII range only, which the ==i / ==+i operators reproduce exactly; every other
+   (?...) group -- lookahead, non-capturing, other flags -- is left as a regex."
+  [p]
+  (let [ci?  (string/starts-with? p "(?i)")
+        body (if ci? (subs p 4) p)]
+    (when-not (string/includes? body "(?")
+      [ci? body])))
+
+(defn- regex-node?
+  [node]
+  (and (vector? node)
+       (= :boolean_test (first node))
+       (= 4 (count node))
+       (vector? (nth node 2))
+       (= :REGEX_OPERATOR (first (nth node 2)))
+       (vector? (last node))
+       (string? (second (last node)))))
+
+(defn- terminal-rule
+  "Builds a rule that rewrites one terminal shape into a string operator.
+   `ci-op` is used only when the literal actually contains an ASCII letter: (?i) over a
+   literal with no letters folds nothing, so those collapse to the cheaper exact op."
+  [shape-re plain-op ci-op]
+  {:pred (fn [node]
+           (and (regex-node? node)
+                (let [[_ body] (split-ci (second (last node)))]
+                  (boolean (and body (re-matches shape-re body))))))
+   :apply (fn [node]
+            (let [[ci? body] (split-ci (second (last node)))
+                  term (unescape (second (re-matches shape-re body)))
+                  fold? (and ci? (boolean (re-find #"[A-Za-z]" term)))]
+              [:boolean_test
+               (second node)
+               [:BINARY_OPERATOR (if fold? ci-op plain-op)]
+               term]))})
+
+;;;; ---------------------------------------------------------------------------------
+;;;; Alternation.
+;;;;
+;;;; Because ==~ is a full-region match, matches(A|B|C) is exactly
+;;;; matches(A) or matches(B) or matches(C) -- the alternation distributes over the
+;;;; whole predicate. So an alternation is split into an OR of independent tests and
+;;;; each branch picks its own operator.
+;;;;
+;;;; This is the only correct treatment. Collapsing an alternation into a single list
+;;;; operator is wrong whenever the branches do not all have the same shape:
+;;;; `.*Error.*|.*Fatal` is contains-or-endsWith, and evaluating it as
+;;;; contains-any(Error, Fatal) reports a match for "xFatalY", which the regex rejects.
+;;;;
+;;;; The split only fires when *every* branch is itself a terminal shape. A branch that
+;;;; stayed a regex would leave two Matcher.matches calls where there was one.
+;;;; ---------------------------------------------------------------------------------
+
+(defn- scan-alternatives
+  "Splits on the `|` at group depth 0, honouring backslash escapes -- an escaped `\\|` is a
+   literal and not a separator. Returns nil if the pattern uses a character class or a
+   backreference, or if its parens are unbalanced; otherwise a vector of branches, which
+   is a single element when there is no top-level `|`.
+
+   A plain string/split on `|` cannot be used here: it would cut `a\\|b|c` into three
+   branches instead of two, and the resulting terms would carry a stray backslash."
+  [body]
+  (let [n (count body)]
+    (loop [i 0 depth 0 start 0 acc []]
+      (if (>= i n)
+        (when (zero? depth) (conj acc (subs body start)))
+        (let [c (.charAt ^String body i)]
+          (cond
+            (= c \\) (when-not (and (< (inc i) n)
+                                    (Character/isDigit (.charAt ^String body (inc i))))
+                       (recur (+ i 2) depth start acc))
+            (= c \[) nil
+            (= c \() (recur (inc i) (inc depth) start acc)
+            (= c \)) (if (zero? depth) nil (recur (inc i) (dec depth) start acc))
+            (and (= c \|) (zero? depth))
+            (recur (inc i) depth (inc i) (conj acc (subs body start i)))
+            :else (recur (inc i) depth start acc)))))))
+
+(defn- top-level-alternatives
+  "scan-alternatives, but only when there really is a top-level alternation to split."
+  [body]
+  (when-let [branches (scan-alternatives body)]
+    (when (> (count branches) 1) branches)))
+
+(def ^:private terminal-shapes [equals-re starts-re ends-re contains-re])
+
+(defn- terminal-branch?
+  [branch]
+  (and (not (string/includes? branch "(?"))
+       (boolean (some #(re-matches % branch) terminal-shapes))))
+
+(defn- or-tree
+  "Left-nested OR, matching the grammar's
+   search_condition = boolean_term | search_condition or_kw boolean_term."
+  [tests]
+  (reduce (fn [acc t] [:search_condition acc [:or_kw "or"] t])
+          (first tests)
+          (rest tests)))
+
+(def ^:private alternation-split-rule
+  {:pred (fn [node]
+           (and (regex-node? node)
+                (let [[_ body] (split-ci (second (last node)))]
+                  (boolean
+                    (when body
+                      (when-let [branches (top-level-alternatives body)]
+                        (and (> (count branches) 1)
+                             (every? terminal-branch? branches))))))))
+   :apply (fn [node]
+            (let [[ci? body] (split-ci (second (last node)))
+                  prefix (if ci? "(?i)" "")
+                  branches (top-level-alternatives body)]
+              ;; The wrapping :boolean_test is what keeps this rewrite composable.
+              ;; binary-expr->pred has a 1-arity pass-through, so a :boolean_test with a
+              ;; single child transforms to just that child's predicate -- the node tag
+              ;; survives for any enclosing rule, and zip/next descends into the new
+              ;; children, so the terminal rules above rewrite each branch in this pass.
+              [:boolean_test
+               (or-tree (for [b branches]
+                          [:boolean_test
+                           (second node)
+                           [:REGEX_OPERATOR "==~"]
+                           [:re_expression (str prefix b)]]))]))})
+
+;;;; A group wrapping the entire pattern carries no meaning once there are no
+;;;; backreferences, and removing it lets the alternation split see the `|`s as
+;;;; top-level: `(master|release)` becomes `master|release`.
+
+(defn- self-contained-group?
+  "True when body is a single group spanning the whole pattern -- `(a|b)` and not
+   `(a)(b)`, which would lose the concatenation if the outer parens were dropped."
+  [body]
+  (and (string/starts-with? body "(")
+       (string/ends-with? body ")")
+       (not (re-find #"\\[1-9]" body))
+       (let [inner (subs body 1 (dec (count body)))
+             n (count inner)]
+         (and (pos? n)
+              (loop [i 0 depth 0]
+                (cond
+                  (>= i n) (zero? depth)
+                  (= \\ (.charAt ^String inner i)) (recur (+ i 2) depth)
+                  (= \( (.charAt ^String inner i)) (recur (inc i) (inc depth))
+                  (= \) (.charAt ^String inner i)) (if (zero? depth)
+                                                     false
+                                                     (recur (inc i) (dec depth)))
+                  :else (recur (inc i) depth)))))))
+
+(def ^:private strip-outer-group-rule
+  {:pred (fn [node]
+           (and (regex-node? node)
+                (let [[_ body] (split-ci (second (last node)))]
+                  (boolean (and body (self-contained-group? body))))))
+   :apply (fn [node]
+            (let [[ci? body] (split-ci (second (last node)))]
+              [:boolean_test
+               (second node)
+               [:REGEX_OPERATOR "==~"]
+               [:re_expression (str (if ci? "(?i)" "")
+                                    (subs body 1 (dec (count body))))]]))})
+
+;;;; Uniform alternations. When every branch of an alternation is a bare literal, every
+;;;; branch really does reduce to the same operator, so the whole pattern collapses to one
+;;;; list operator instead of the chain of ORs the general split would produce. Literals
+;;;; adjacent to the group distribute into each term: `pre(a|b)post` is
+;;;; equals-any(preapost, prebpost).
+;;;;
+;;;; Anything these decline -- in particular any alternation whose branches have differing
+;;;; shapes -- falls through to alternation-split-rule, which is the only correct treatment
+;;;; there. Collapsing a mixed alternation into one list operator is a real bug:
+;;;; `.*Error.*|.*Fatal` as contains-any(Error, Fatal) accepts "xFatalY", which the regex
+;;;; rejects.
+
+(defn- alt-rule
+  "Builds a rule for `<lead><prefix>(a|b|...)<suffix><trail>`, where lead/trail are the
+   fixed `.*` decorations that select the operator and prefix/suffix are optional
+   literals that distribute into every term."
+  [lead trail plain-op ci-op]
+  (let [shape (re-pattern (str "\\^?" lead "(" word-src ")?\\((" word-src
+                               "(?:\\|" word-src ")*)\\)(" word-src ")?" trail "\\$?"))]
+    {:pred (fn [node]
+             (and (regex-node? node)
+                  (let [[_ body] (split-ci (second (last node)))]
+                    (boolean (and body (re-matches shape body))))))
+     :apply (fn [node]
+              (let [[ci? body] (split-ci (second (last node)))
+                    [_ prefix alts suffix] (re-matches shape body)
+                    prefix (unescape (or prefix ""))
+                    suffix (unescape (or suffix ""))
+                    words (map #(str prefix (unescape %) suffix)
+                               (scan-alternatives alts))
+                    fold? (and ci? (boolean (some #(re-find #"[A-Za-z]" %) words)))]
+                [:boolean_test
+                 (second node)
+                 [:BINARY_OPERATOR (if fold? ci-op plain-op)]
+                 words]))}))
+
+;;;; The paren-free form, `a|b|c`. strip-outer-group-rule has already unwrapped
+;;;; `(a|b|c)` by the time this runs, so this covers both.
+(def ^:private bare-multi-equals-rule
+  ;; The whole alternation is a capture group rather than something recovered by trimming
+  ;; `^`/`$` off the ends: a pattern may legitimately *end* in an escaped `\$`, and a
+  ;; trailing-`$` string replace would eat that dollar and leave a dangling backslash in
+  ;; the term. Reading the group off the match cannot make that mistake, because the
+  ;; literal class already decided which dollar is a metacharacter.
+  (let [shape (re-pattern (str "\\^?((?:" word-src ")(?:\\|(?:" word-src "))+)\\$?"))]
+    {:pred (fn [node]
+             (and (regex-node? node)
+                  (let [[_ body] (split-ci (second (last node)))]
+                    (boolean (and body (re-matches shape body))))))
+     :apply (fn [node]
+              (let [[ci? body] (split-ci (second (last node)))
+                    words (map unescape (scan-alternatives (second (re-matches shape body))))
+                    fold? (and ci? (boolean (some #(re-find #"[A-Za-z]" %) words)))]
+                [:boolean_test
+                 (second node)
+                 [:BINARY_OPERATOR (if fold? "==i" "==*")]
+                 words]))}))
+
+;;;; ---------------------------------------------------------------------------------
+;;;; Rule order is significant. `reduce` threads one location through every rule in
+;;;; turn, so a rule sees whatever its predecessors produced:
+;;;;
+;;;;   strip-outer-group  runs first so the multi-term rules and the split see the
+;;;;                      unwrapped pattern.
+;;;;   terminals          run before the multi-term rules, so a single-literal pattern
+;;;;                      becomes `==` rather than a one-element `==*`.
+;;;;   multi-term rules   take the uniform alternations, which they express as one list
+;;;;                      operator.
+;;;;   alternation-split  is the fallback for every other alternation, and cannot loop:
+;;;;                      its output branches contain no top-level `|`.
+;;;;
+;;;; A rule that has already fired leaves a :BINARY_OPERATOR behind, so every later
+;;;; predicate declines it via regex-node?.
+;;;; ---------------------------------------------------------------------------------
 
 (def optimization-rules
-  [
-   ;;;; Basic equals rule, converts foo ==~ /abcd/ into an equals call.
-   {:pred (fn [node] (and (= :boolean_test (first node))
-                          (= (first (nth node 2)) :REGEX_OPERATOR)
-                          (re-matches
-                            word-regex
-                            (second (last node)))))
-    :apply (fn [node] [:boolean_test
-                       (second node)
-                       [:BINARY_OPERATOR "=="]
-                       (unescape (second (last node)))
-                       ])}
+  [strip-outer-group-rule
 
-   ;;;; Basic starts with rule, converts foo ==~ /abcd.*/ into a startswith call.
-   {:pred (fn [node] (and (= :boolean_test (first node))
-                         (= (first (nth node 2)) :REGEX_OPERATOR)
-                         (re-matches
-                           #"\^?(?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\"|\\/|\\\(|\\\)|\\\{|\\\})+\.\*$"
-                           (second (last node)))))
-   :apply (fn [node] [:boolean_test
-                      (second node)
-                      [:BINARY_OPERATOR "startsWith"]
-                      (clojure.string/replace
-                        (unescape (subs (second (last node)) 0 (- (count (second (last node))) 2)))
-                        #"^\^"
-                        "")]) 
-   }
+   (terminal-rule equals-re   "==" "==i")
+   (terminal-rule starts-re   "startsWith" "startsWithi")
+   (terminal-rule ends-re     "endsWith" "endsWithi")
+   (terminal-rule contains-re "==+" "==+i")
 
-   ;;;; Basic contrains rule, converts foo ==~ /.*abcd.*/ into a contains call.
-   {:pred (fn [node] (and (= :boolean_test (first node))
-                          (= (first (nth node 2)) :REGEX_OPERATOR)
-                          (re-matches
-                            #"\.\*(?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\"|\\/|\\\(|\\\)|\\\{|\\\})+\.\*"
-                            (second (last node)))))
-    :apply (fn [node] [:boolean_test
-                       (second node)
-                       [:BINARY_OPERATOR "==+"]
-                        (unescape (subs (second (last node)) 2 (- (count (second (last node))) 2)))
-                        ])}
+   bare-multi-equals-rule
+   (alt-rule ""       ""       "==*" "==i")
+   (alt-rule "\\.\\*" "\\.\\*" "==+" "==+i")
+   (alt-rule ""       "\\.\\*" "startsWith" "startsWithi")
+   (alt-rule "\\.\\*" ""       "endsWith" "endsWithi")
 
-   ;;;; Multiple equals rule, converts foo ==~ /abc|def|ghi/ into multiple equals calls. 
-   {:pred (fn [node] (and (= :boolean_test (first node))
-                          (= (first (nth node 2)) :REGEX_OPERATOR)
-                          (re-matches
-                            #"(?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\"|\\/|\\\(|\\\)|\\\{|\\\})+(\|(?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\"|\\/|\\\(|\\\)|\\\{|\\\})+)*"
-                                      (second (last node)))))
-    :apply (fn [node] 
-             (let
-               [target (subs (second (last node)) 3 (- (count (second (last node))) 3))
-                words (map unescape (string/split (second (last node)) #"\|"))
-                ]
-               [:boolean_test
-                (second node)
-                [:BINARY_OPERATOR "==*"]
-                words])
-             )}
-
-   ;;;; Multiple contrains rule, converts foo ==~ /.*(abc|def).*/ into multiple contains calls.
-   {:pred (fn [node] (and (= :boolean_test (first node))
-                          (= (first (nth node 2)) :REGEX_OPERATOR)
-                          (re-matches
-                            #"\.\*\((?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\"|\\/|\\\(|\\\)|\\\{|\\\})+(\|(?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\"|\\/|\\\(|\\\)|\\\{|\\\})+)*\)\.\*"
-                                      (second (last node)))))
-    :apply (fn [node] 
-             (let
-               [target (subs (second (last node)) 3 (- (count (second (last node))) 3))
-                words (map unescape (string/split target #"\|"))]
-               [:boolean_test
-                (second node)
-                [:BINARY_OPERATOR "==+"]
-                words])
-             )}
-
-   ;;;; Prefix multiple contrains rule, converts foo ==~ /.*(abc|def)ghi.*/ into multiple contains calls.
-   {:pred (fn [node] (and (= :boolean_test (first node))
-                          (= (first (nth node 2)) :REGEX_OPERATOR)
-                          (re-matches
-                            #"\.\*\((?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\"|\\/|\\\(|\\\)|\\\{|\\\})+(\|(?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\"|\\/|\\\(|\\\)|\\\{|\\\})+)+\)(?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\ |\\/|\\\(|\\\)|\\\{|\\\})+\.\*"
-                                      (second (last node)))))
-    :apply (fn [node] 
-             (let
-               [target (subs (second (last node)) 3 (- (count (second (last node))) 2))
-                ;; TODO: Separate the tail, and then this will be the same.
-                tail (last (string/split target #"\)"))
-                words (map unescape (string/split (string/replace target (str ")" tail) "") #"\|"))]
-               [:boolean_test
-                (second node)
-                [:BINARY_OPERATOR "==+"]
-                (map #(str %1 tail) words)])
-             )}
-   ])
+   alternation-split-rule])
 
 (defn- apply-rules
   [loc rules]
-  (reduce apply-rule loc optimization-rules))
+  (reduce apply-rule loc rules))
 
 (defn run
   [loc]

--- a/mql-jvm/src/main/clojure/io/mantisrx/mql/optimization.cljc
+++ b/mql-jvm/src/main/clojure/io/mantisrx/mql/optimization.cljc
@@ -27,24 +27,20 @@
 ;;;; Regex below defines a "word" for MQL optimization purposes.
 ;;;; This is any unit of text that we might consider an input token
 ;;;; to a regex which we might extract and use in other manners.
-;;;; Allows alphanumeric, _, :, double quotes, -, \., \:, \", \/, \(, \)
-;;;; This allows users to search JSON
+;;;; Allows any character that is a literal in a regex -- i.e. anything that is
+;;;; not a metacharacter -- plus a backslash escape of any metacharacter. Every
+;;;; character outside the metacharacter set matches only itself, so a pattern
+;;;; built solely from them is exactly a literal string.
 (def word-regex
-  #"(?:[A-Za-z0-9_:\"-]|\\\.|\\:|\\\"|\\/|\\\(|\\\)|\\\{|\\\})+"
+  #"(?:[^\\.*+?()\[\]{}|^$]|\\[.*+?()\[\]{}|^$\\/\"])+"
   )
 
+;;;; Strips the backslash from every escape word-regex admits. Single-pass and
+;;;; left-to-right, so an escaped backslash consumes its own escapee rather than
+;;;; being re-examined as the escape of the character after it.
 (defn unescape
   [x]
-  (-> x
-       (string/replace "\\:" ":")
-       (string/replace "\\." ".")
-       (string/replace "\\/" "/")
-       (string/replace "\\(" "(")
-       (string/replace "\\)" ")")
-       (string/replace "\\\"" "\"")
-       (string/replace "\\}" "}")
-       (string/replace "\\{" "{")
-       ))
+  (string/replace x #"\\([.*+?()\[\]{}|^$\\/\"])" "$1"))
 
 (def optimization-rules
   [

--- a/mql-jvm/src/test/clojure/io/mantisrx/mql/test_optimization.clj
+++ b/mql-jvm/src/test/clojure/io/mantisrx/mql/test_optimization.clj
@@ -1,0 +1,127 @@
+(ns io.mantisrx.mql.test-optimization
+  "Differential tests for the optimizer.
+
+   Every rule in optimization.cljc replaces a regex with string operators, so the property
+   worth testing is not the shape of the rewritten tree but that the rewrite decides exactly
+   what the regex decided -- for every input, including the ones that make the two disagree.
+   Each test below therefore compiles the pattern with java.util.regex under the same flags
+   MQL uses (DOTALL only, see transformers.cljc), runs the optimized tree, and asserts the
+   two agree; a rule that declines to fire still passes, because the unoptimized tree is the
+   regex itself.
+
+   The predicates are built with where/binary-expr->pred and where/search-condition->pred --
+   the same functions transformers.cljc wires the parse tree through -- so the operators under
+   test are the ones that ship, not a transcription of them."
+  (:require [clojure.test :refer :all]
+            [clojure.zip :as zip]
+            [clojure.string :as string]
+            [io.mantisrx.mql.optimization :as opt]
+            [io.mantisrx.mql.compilers.core.where :as where])
+  (:import [java.util.regex Pattern]))
+
+(def ^:private prop (fn [datum] (get datum "a")))
+
+(defn- regex-tree
+  [pattern]
+  [:boolean_test prop [:REGEX_OPERATOR "==~"] [:re_expression pattern]])
+
+(defn- optimize
+  [pattern]
+  (opt/run (zip/vector-zip (regex-tree pattern))))
+
+(defn- ->pred
+  "Compiles an optimized tree into a predicate, mirroring the transformers.cljc wiring."
+  [node]
+  (case (first node)
+    :boolean_test (if (= 2 (count node))
+                    (->pred (second node))
+                    (where/binary-expr->pred
+                      (nth node 1)
+                      (second (nth node 2))
+                      (let [operand (last node)]
+                        (if (and (vector? operand) (= :re_expression (first operand)))
+                          (Pattern/compile (second operand) Pattern/DOTALL)
+                          operand))))
+    :boolean_term (if (= 2 (count node))
+                    (->pred (second node))
+                    (where/boolean-term->pred (->pred (nth node 1)) nil (->pred (nth node 3))))
+    :search_condition (if (= 2 (count node))
+                        (->pred (second node))
+                        (where/search-condition->pred
+                          (->pred (nth node 1)) nil (->pred (nth node 3))))))
+
+(defn- differs
+  "Inputs on which the optimized tree disagrees with the pattern it was derived from."
+  [pattern inputs]
+  (let [compiled (Pattern/compile pattern Pattern/DOTALL)
+        pred (->pred (optimize pattern))]
+    (for [in inputs
+          :let [expected (.matches (.matcher compiled ^String in))
+                actual (boolean (pred {"a" in}))]
+          :when (not= expected actual)]
+      {:input in :regex expected :optimized actual})))
+
+(defn- rewritten?
+  [pattern]
+  (not= (optimize pattern) (regex-tree pattern)))
+
+;;;; Inputs are shared across patterns on purpose: an input that is irrelevant to one pattern
+;;;; is often the counterexample for another, and a rule that over-fires is far more likely to
+;;;; be caught by an input drawn from a neighbouring case than by one tailored to its own.
+(def ^:private inputs
+  ["" "a" "abba" "abba1234" "1234abba" "xabbax" "dabba" "ABBA" "AbBa" "abb" "abbaabba"
+   "abba\n" "\nabba" "abc" "def" "ghi" "xyz" "abcdef" "xabc" "abcx" "xabcx"
+   "prod" "PROD" "Prod" "test-prod-1" "production" "nonprod" "17.32.0" "17.32.O"
+   "a.b" "a|b" "aXb" "a\\b" "a$" "a$b" "$" "^a" "(focus)" "(focus)test" "x(focus)"
+   "{\"prop\":\"123\"}" "prop\":\"123" "123" "k" "K" "K" "s" "S" "ſ"
+   "straße" "STRASSE" "i" "I" "İ" "ı" "é" "É"])
+
+(deftest test-terminal-shapes-preserve-semantics
+  (doseq [pattern ["abba" "^abba" "abba$" "^abba$"
+                   "abba.*" "^abba.*"
+                   ".*abba" ".*abba$"
+                   ".*abba.*" "^.*abba.*$"
+                   "a\\.b" "\\(focus\\)" "^\\(focus\\).*" ".*prop\\\"\\:\\\"123.*"]]
+    (testing pattern
+      (is (rewritten? pattern) "expected the optimizer to rewrite this shape")
+      (is (empty? (differs pattern inputs))))))
+
+(deftest test-case-insensitive-folding-is-ascii-only
+  (testing "(?i) in MQL is ASCII-only, because patterns compile without UNICODE_CASE.
+            equalsIgnoreCase and regionMatches(true, ...) fold more than that, so the *i
+            operators must not be implemented with them."
+    (doseq [pattern ["(?i)abba" "(?i)abba.*" "(?i).*abba" "(?i).*abba.*"
+                     "(?i)k" "(?i)s" "(?i)i" "(?i)straße" "(?i).*prod.*"]]
+      (testing pattern
+        (is (rewritten? pattern))
+        (is (empty? (differs pattern inputs))))))
+  (testing "a (?i) over a literal with no ASCII letter folds nothing, so it collapses to the
+            cheaper case-sensitive operator."
+    (is (= [:boolean_test prop [:BINARY_OPERATOR "=="] "17.32.0"]
+           (optimize "(?i)17\\.32\\.0")))))
+
+(deftest test-alternations-preserve-semantics
+  (doseq [pattern ["abc|def|ghi" "^abc|def|ghi$" "(abc|def)" ".*(abc|def).*"
+                   "pre(abc|def)" "(abc|def)post" "pre(abc|def)post"
+                   ".*(abc|def)" "(abc|def).*"
+                   "abba.*|.*abc" ".*abba.*|.*abc" "abc|.*def.*|ghi.*"
+                   "a\\|b|c" "(?i)abc|def"]]
+    (testing pattern
+      (is (rewritten? pattern))
+      (is (empty? (differs pattern inputs))))))
+
+(deftest test-mixed-shape-alternation-is-not-collapsed
+  (testing "A mixed alternation must become an OR of per-branch operators, never one list
+            operator: as `contains-any(abc, def)` the pattern below would accept \"xdefy\",
+            which the regex rejects because that branch is anchored at the end."
+    (is (empty? (differs ".*abc.*|.*def" (conj inputs "xdefy" "xdef" "abcdef" "defx"))))))
+
+(deftest test-unsupported-constructs-are-left-alone
+  (testing "Rules must decline anything whose semantics they cannot reproduce exactly."
+    (doseq [pattern ["\\d+" "\\w" "\\s" "\\Qa.b\\E" "\\p{Alpha}" "(a)\\1" "\\babba\\b"
+                     "[abc]" "[^a]" "a{2}" "a+" "a?" "a.*b.*c" ".*a.*b.*"
+                     "(a|b)(c|d)" "(a)(b)" "(?:a)" "(?<=a)b" "((?!abba).)*"
+                     "(?s)a" "(?m)a" "a(?i)b" "" ".*" "^" "$"]]
+      (testing pattern
+        (is (not (rewritten? pattern)) "expected the optimizer to decline this pattern")
+        (is (empty? (differs pattern inputs)))))))


### PR DESCRIPTION
## What

`io.mantisrx.mql.optimization` exists to rewrite `==~` regex predicates into string operations so `where` clauses don't run `Matcher.matches` per event. It was, in practice, never firing on production queries. This reworks the rule set so it does.

## Why it wasn't firing

The rules keyed off `word-regex`, which accepted only `[A-Za-z0-9-_]+`. Nearly every real pattern contains a dot, a slash, a colon, or an escape, so nearly every real pattern fell through to `Matcher.matches`. Widening that class (first commit here) fixed the trivial cases and left the bulk of the corpus untouched, because the rules only ever matched a *single bare literal* — and most production patterns are alternations, or wrap the whole thing in a redundant group, or carry `(?i)`.

Measured on the shared `mantisagent` app via fleet-wide continuous profiling (2026-08-11, re-checked 2026-08-17):

- `Matcher.matches` reached through the MQL `where` frame is **7.71% cumulative CPU** for the app, and **98.8%** of all `Matcher.matches` samples in the app enter through that one frame.
- That frame is ~48% of `MQLQuery.matches` overall (16.00% cumulative).
- `Pattern.compile` is negligible in steady state (0.003%), so this is evaluation cost, not compilation cost — which is what makes the rewrite worth doing rather than caching.

## What changed

| shape | before | after |
|---|---|---|
| `(a\|b\|c)` | not rewritten | `==*` over a term collection |
| `.*(a\|b).*` | not rewritten | `==+` over a term collection |
| `(a\|b).*` / `.*(a\|b)` | not rewritten | `startsWith` / `endsWith` over a collection |
| `(.*foo.*)` | not rewritten | outer group stripped, then `==+` |
| `(?i)foo` | not rewritten | `==i` (and the `i` variants of the affix ops) |
| mixed alternation, e.g. `.*a.*\|b.*` | not rewritten | `or` tree of per-branch operators |
| `a\|b\:c` | **rewritten wrongly** | correct — see below |

Rule order matters and is explicit in `optimization-rules`: strip the redundant outer group first, then try the single-terminal rules, then the folded-alternation rules, and only fall back to splitting into an `or` tree.

The alternation scanner respects escapes and group depth rather than calling `string/split` on `|` — the old approach turned `a\|b|c` into three terms including a dangling backslash.

**`where.cljc`:** the four affix operators (`startsWith`, `endsWith`, `startsWithi`, `endsWithi`) now accept a collection of terms as well as a bare string, via a shared `coll-some` helper — this is how `==+` and `==*` already behaved, so folding an alternation into one operator now has somewhere to land. The case-insensitive helpers fold ASCII in place rather than allocating a lower-cased copy of the input per comparison.

## Coverage

Against the distinct `==~` patterns observed on the fleet, weighted by occurrence count:

```
before (this branch's first commit only) : 85 distinct /  7,673 occ (61.7%),  8 patterns semantically wrong / 466 occ
after  (this branch)                     : 100 distinct / 12,327 occ (99.2%), 0 wrong
```

Against the narrower subset that actually appears in CPU profiles (4,753 occurrences): **97.9%**.

Resulting operator mix: `==+` 6,952 · `startsWith` 6,190 · `==` 1,683 · `==+i` 1,542 · `endsWith` 598 · `==*` 439.

Remaining 0.8% (5 patterns / 99 occ), both deliberate:

- `.*ui.*error.*|.*startplay.*|…` (91 occurrences) — needs an *ordered multi-contains* operator (match several substrings in sequence), which is new operator surface and out of scope here.
- Four patterns of the form `((?!playapi-logblob).)*` (2 occurrences each) — negative lookahead, irreducible to string ops.

## Three pre-existing defects found

1. **`apply-rules` ignored its own `rules` parameter** and always reduced over the global `optimization-rules`. Fixed. Nothing depended on the broken behaviour because the only caller passed the global list anyway, but it made the function untestable in isolation.
2. **Rule 6's inlined character class had `\\\ ` (backslash-space) where the sibling rules had `\\\"`** — a typo, and part of why that rule never matched what it was meant to.
3. **`apply-rule` swallows predicate exceptions** via `(catch Exception e (identity false))`, so a broken rule silently declines to fire rather than failing. I've left this in place — changing it is a behavioural change to error handling and belongs in its own PR — but every predicate added here has explicit guards so it doesn't rely on the catch.

## Verification

**`./gradlew :mql-jvm:test` could not be run locally.** Build-plugin resolution fails from this environment for `gradle-scalastyle-plugin_2.11:1.0.1`, `de.kotka.gradle:gradle-utils:0.2.2`, and `org.ajoberstar.grgit:grgit-core:4.0.2`, both online and offline, and `instaparse` is not resolvable either. **CI needs to run the suite before this merges** — I don't want that ambiguity buried.

What I could run, via a standalone Clojure classpath assembled from the Gradle cache:

```
repo test_optimization.clj  : 5 tests / 128 assertions   — 0 failures, 0 errors
prod-corpus differential    : 105 patterns / 12,426 occ  — 0 mismatches, 5,744 inputs
adversarial differential    : 105 patterns, 69 rewritten — 0 mismatches, 5,817 inputs
fuzz (seed 20260817)        : 40,000 generated, 21,843 rewritten — 0 mismatches
fuzz (seed 987654321)       : 40,000 generated, 21,759 rewritten — 0 mismatches
```

The differential harness is the load-bearing part. For each pattern it compiles the real `java.util.regex.Pattern` (with `DOTALL`, matching how `transformers.cljc` wires it), runs the optimizer, evaluates the rewritten tree through **the shipping `ops` table read directly out of `where.cljc`** — not a transcription, precisely so it cannot drift from the code under test — and asserts the two agree on every generated input. Inputs are derived per pattern from its own literal runs, with case variations, prefixes/suffixes, and Unicode edge cases (`é`, `ſ`, `ß`, `K`, `İ`, embedded newlines) chosen to catch the ASCII-folding and `DOTALL` assumptions specifically.

Mismatches it caught during development, all fixed:

- `a\|b|c` → three terms including a dangling `\` (naive `|` split).
- Patterns with an escaped trailing `$` — the multi-equals rule stripped `$` with `(string/replace #"\$" "")` regardless of escaping.
- `\:` mangled by the first commit's widened `word-src` — 8 patterns, 466 occurrences. This is the regression the coverage table above reports as "8 wrong"; it is fixed by the new `unescape` plus a widened escape branch in `word-src`.
- Two of the repo's own existing tests (`.*(abc|def)`, `(abc|def).*`) failed until the four affix operators were routed through `coll-some`.

## Note on the duplicated file

`mql/optimization.cljc` and `mql/jvm/optimization.clj` are two near-identical copies that both ship; only the `ns` form differs (first 24 lines). Both are updated here and verified identical below the header:

```
diff <(sed -n '4,$p' optimization.cljc) <(sed -n '25,$p' jvm/optimization.clj)
```

I have not tried to collapse them — that's a packaging change, separate from this.

## Not included

I wrote a JMH benchmark for the evaluation path but am holding it back rather than shipping code I could not compile here (same plugin-resolution problem as the test suite). Happy to add it in a follow-up once CI confirms the build works, or now if you'd rather review it unrun.
